### PR TITLE
fix: Package subpath './lib' is not defined by 'exports' in 'onewheel…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
         "eslint": "^8.15.0",
         "eslint-config-prettier": "^8.5.0",
         "happy-dom": "^3.2.0",
-        "msw": "^0.39.2",
+        "msw": "^0.47.3",
         "npm-run-all": "^4.1.5",
         "postcss": "^8.4.13",
         "prettier": "2.6.2",
@@ -2392,9 +2392,9 @@
       }
     },
     "node_modules/@mswjs/cookies": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@mswjs/cookies/-/cookies-0.2.1.tgz",
-      "integrity": "sha512-0tDfcPw5/s7QsNQqS3knAvAD5w5PF1nNPagRhKO/yECY+sMbJxoC2sLWnH7Lzmh52mTSVLKDhd1r92Q3kfljnQ==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@mswjs/cookies/-/cookies-0.2.2.tgz",
+      "integrity": "sha512-mlN83YSrcFgk7Dm1Mys40DLssI1KdJji2CMKN8eOlBqsTADYzj2+jWzsANsUTFbxDMWPD5e9bfA1RGqBpS3O1g==",
       "dev": true,
       "dependencies": {
         "@types/set-cookie-parser": "^2.4.0",
@@ -2405,17 +2405,19 @@
       }
     },
     "node_modules/@mswjs/interceptors": {
-      "version": "0.15.1",
-      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.15.1.tgz",
-      "integrity": "sha512-D5B+ZJNlfvBm6ZctAfRBdNJdCHYAe2Ix4My5qfbHV5WH+3lkt3mmsjiWJzEh5ZwGDauzY487TldI275If7DJVw==",
+      "version": "0.17.5",
+      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.17.5.tgz",
+      "integrity": "sha512-/uZkyPUZMRExZs+DZQVnc+uoDwLfs1gFNvcRY5S3Gu78U+uhovaSEUW3tuyld1e7Oke5Qphfseb8v66V+H1zWQ==",
       "dev": true,
       "dependencies": {
         "@open-draft/until": "^1.0.3",
+        "@types/debug": "^4.1.7",
         "@xmldom/xmldom": "^0.7.5",
         "debug": "^4.3.3",
-        "headers-polyfill": "^3.0.4",
+        "headers-polyfill": "^3.1.0",
         "outvariant": "^1.2.1",
-        "strict-event-emitter": "^0.2.0"
+        "strict-event-emitter": "^0.2.4",
+        "web-encoding": "^1.1.5"
       },
       "engines": {
         "node": ">=14"
@@ -8812,9 +8814,9 @@
       }
     },
     "node_modules/headers-polyfill": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-3.0.7.tgz",
-      "integrity": "sha512-JoLCAdCEab58+2/yEmSnOlficyHFpIl0XJqwu3l+Unkm1gXpFUYsThz6Yha3D6tNhocWkCPfyW0YVIGWFqTi7w==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-3.1.0.tgz",
+      "integrity": "sha512-AVwgTAzeGpF7kwUCMc9HbAoCKFcHGEfmWkaI8g0jprrkh9VPRaofIsfV7Lw8UuR9pi4Rk7IIjJce8l0C+jSJNA==",
       "dev": true
     },
     "node_modules/history": {
@@ -11617,30 +11619,31 @@
       "dev": true
     },
     "node_modules/msw": {
-      "version": "0.39.2",
-      "resolved": "https://registry.npmjs.org/msw/-/msw-0.39.2.tgz",
-      "integrity": "sha512-ju/HpqQpE4/qCxZ23t5Gaau0KREn4QuFzdG28nP1EpidMrymMJuIvNd32+2uGTGG031PMwrC41YW7vCxHOwyHA==",
+      "version": "0.47.3",
+      "resolved": "https://registry.npmjs.org/msw/-/msw-0.47.3.tgz",
+      "integrity": "sha512-X3w/1fi29mEqoCajgFV59hrmns+mdD/FPegYMRwW7CK0vi//yX9NVy07/XspdBm6W1TNtb8Giv79SmS2BAb0Wg==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
-        "@mswjs/cookies": "^0.2.0",
-        "@mswjs/interceptors": "^0.15.1",
+        "@mswjs/cookies": "^0.2.2",
+        "@mswjs/interceptors": "^0.17.5",
         "@open-draft/until": "^1.0.3",
         "@types/cookie": "^0.4.1",
         "@types/js-levenshtein": "^1.1.1",
         "chalk": "4.1.1",
         "chokidar": "^3.4.2",
         "cookie": "^0.4.2",
-        "graphql": "^16.3.0",
-        "headers-polyfill": "^3.0.4",
+        "graphql": "^15.0.0 || ^16.0.0",
+        "headers-polyfill": "^3.1.0",
         "inquirer": "^8.2.0",
         "is-node-process": "^1.0.1",
         "js-levenshtein": "^1.1.6",
         "node-fetch": "^2.6.7",
+        "outvariant": "^1.3.0",
         "path-to-regexp": "^6.2.0",
         "statuses": "^2.0.0",
         "strict-event-emitter": "^0.2.0",
-        "type-fest": "^1.2.2",
+        "type-fest": "^2.19.0",
         "yargs": "^17.3.1"
       },
       "bin": {
@@ -11652,6 +11655,14 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mswjs"
+      },
+      "peerDependencies": {
+        "typescript": ">= 4.2.x <= 4.8.x"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/msw/node_modules/chalk": {
@@ -11686,12 +11697,12 @@
       }
     },
     "node_modules/msw/node_modules/type-fest": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
-      "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
       "dev": true,
       "engines": {
-        "node": ">=10"
+        "node": ">=12.20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -18640,9 +18651,9 @@
       }
     },
     "@mswjs/cookies": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@mswjs/cookies/-/cookies-0.2.1.tgz",
-      "integrity": "sha512-0tDfcPw5/s7QsNQqS3knAvAD5w5PF1nNPagRhKO/yECY+sMbJxoC2sLWnH7Lzmh52mTSVLKDhd1r92Q3kfljnQ==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@mswjs/cookies/-/cookies-0.2.2.tgz",
+      "integrity": "sha512-mlN83YSrcFgk7Dm1Mys40DLssI1KdJji2CMKN8eOlBqsTADYzj2+jWzsANsUTFbxDMWPD5e9bfA1RGqBpS3O1g==",
       "dev": true,
       "requires": {
         "@types/set-cookie-parser": "^2.4.0",
@@ -18650,17 +18661,19 @@
       }
     },
     "@mswjs/interceptors": {
-      "version": "0.15.1",
-      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.15.1.tgz",
-      "integrity": "sha512-D5B+ZJNlfvBm6ZctAfRBdNJdCHYAe2Ix4My5qfbHV5WH+3lkt3mmsjiWJzEh5ZwGDauzY487TldI275If7DJVw==",
+      "version": "0.17.5",
+      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.17.5.tgz",
+      "integrity": "sha512-/uZkyPUZMRExZs+DZQVnc+uoDwLfs1gFNvcRY5S3Gu78U+uhovaSEUW3tuyld1e7Oke5Qphfseb8v66V+H1zWQ==",
       "dev": true,
       "requires": {
         "@open-draft/until": "^1.0.3",
+        "@types/debug": "^4.1.7",
         "@xmldom/xmldom": "^0.7.5",
         "debug": "^4.3.3",
-        "headers-polyfill": "^3.0.4",
+        "headers-polyfill": "^3.1.0",
         "outvariant": "^1.2.1",
-        "strict-event-emitter": "^0.2.0"
+        "strict-event-emitter": "^0.2.4",
+        "web-encoding": "^1.1.5"
       }
     },
     "@nodelib/fs.scandir": {
@@ -23462,9 +23475,9 @@
       "dev": true
     },
     "headers-polyfill": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-3.0.7.tgz",
-      "integrity": "sha512-JoLCAdCEab58+2/yEmSnOlficyHFpIl0XJqwu3l+Unkm1gXpFUYsThz6Yha3D6tNhocWkCPfyW0YVIGWFqTi7w==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-3.1.0.tgz",
+      "integrity": "sha512-AVwgTAzeGpF7kwUCMc9HbAoCKFcHGEfmWkaI8g0jprrkh9VPRaofIsfV7Lw8UuR9pi4Rk7IIjJce8l0C+jSJNA==",
       "dev": true
     },
     "history": {
@@ -25452,29 +25465,30 @@
       "dev": true
     },
     "msw": {
-      "version": "0.39.2",
-      "resolved": "https://registry.npmjs.org/msw/-/msw-0.39.2.tgz",
-      "integrity": "sha512-ju/HpqQpE4/qCxZ23t5Gaau0KREn4QuFzdG28nP1EpidMrymMJuIvNd32+2uGTGG031PMwrC41YW7vCxHOwyHA==",
+      "version": "0.47.3",
+      "resolved": "https://registry.npmjs.org/msw/-/msw-0.47.3.tgz",
+      "integrity": "sha512-X3w/1fi29mEqoCajgFV59hrmns+mdD/FPegYMRwW7CK0vi//yX9NVy07/XspdBm6W1TNtb8Giv79SmS2BAb0Wg==",
       "dev": true,
       "requires": {
-        "@mswjs/cookies": "^0.2.0",
-        "@mswjs/interceptors": "^0.15.1",
+        "@mswjs/cookies": "^0.2.2",
+        "@mswjs/interceptors": "^0.17.5",
         "@open-draft/until": "^1.0.3",
         "@types/cookie": "^0.4.1",
         "@types/js-levenshtein": "^1.1.1",
         "chalk": "4.1.1",
         "chokidar": "^3.4.2",
         "cookie": "^0.4.2",
-        "graphql": "^16.3.0",
-        "headers-polyfill": "^3.0.4",
+        "graphql": "^15.0.0 || ^16.0.0",
+        "headers-polyfill": "^3.1.0",
         "inquirer": "^8.2.0",
         "is-node-process": "^1.0.1",
         "js-levenshtein": "^1.1.6",
         "node-fetch": "^2.6.7",
+        "outvariant": "^1.3.0",
         "path-to-regexp": "^6.2.0",
         "statuses": "^2.0.0",
         "strict-event-emitter": "^0.2.0",
-        "type-fest": "^1.2.2",
+        "type-fest": "^2.19.0",
         "yargs": "^17.3.1"
       },
       "dependencies": {
@@ -25501,9 +25515,9 @@
           "dev": true
         },
         "type-fest": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
-          "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
+          "version": "2.19.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
           "dev": true
         },
         "yargs": {

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "eslint": "^8.15.0",
     "eslint-config-prettier": "^8.5.0",
     "happy-dom": "^3.2.0",
-    "msw": "^0.39.2",
+    "msw": "^0.47.3",
     "npm-run-all": "^4.1.5",
     "postcss": "^8.4.13",
     "prettier": "2.6.2",


### PR DESCRIPTION
### Explanation of the problem (or at least my understanding of it)
In `package.json` file, `devDependencies` package `msw` version `^0.39.2` is used
It will install at least `msw` version `0.45.0` on your computer
and then you will receive as sub dependency newer `headers-polyfill` version `3.1.0` instead of `3.0.4`
here is the diff that causes the problem:
[https://github.com/mswjs/headers-polyfill/compare/v3.0.4...v3.1.0#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R8](https://github.com/mswjs/headers-polyfill/compare/v3.0.4...v3.1.0#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R8)
a new declaration of `exports` will break your npm installation
```
  "exports": {
    ".": {
      "types": "./lib/index.d.ts",
      "require": "./lib/index.js",
      "default": "./lib/esm/index.js"
    }
  }
```
### Solution
 just delete `package-lock.json` and update manually `msw` to version `0.47.3` and reinstall all other packages
```
rm -f -R node_modules
rm -f package-lock.json
npm install msw@0.47.3
npm install 
```
and voila! `npm run dev` is working :)
you will have the right  `headers-polyfill` version via the updated `msw` package and new and well tree-shaked `package-lock.json`

It's my very first "Pull request" in GitLab so probably I wrote the description it the wrong way. 

PS. - related to the reported problem [When executing "npm run dev" there will be an error message. #5](https://github.com/kentcdodds/onewheel-blog/issues/5) that I stepped on the same landmine yesterday and managed to "solve" it today